### PR TITLE
Fix oversized icon: use fixed 2.625rem square matching two text-sm lines

### DIFF
--- a/packages/frontend/src/components/ActiveAgentsList.test.tsx
+++ b/packages/frontend/src/components/ActiveAgentsList.test.tsx
@@ -186,7 +186,7 @@ describe("ActiveAgentsList", () => {
     expect(screen.getByText("Task 1")).toBeInTheDocument();
   });
 
-  it("renders agent icons that scale to match text height with correct aspect ratio", async () => {
+  it("renders agent icons sized to match two lines of text", async () => {
     mockAgentsActive.mockResolvedValue([
       {
         id: "task-1",
@@ -208,6 +208,6 @@ describe("ActiveAgentsList", () => {
     const listbox = screen.getByRole("listbox");
     const icon = listbox.querySelector("img");
     expect(icon).toBeInTheDocument();
-    expect(icon).toHaveClass("self-stretch", "aspect-square");
+    expect(icon).toHaveStyle({ width: "2.625rem", height: "2.625rem" });
   });
 });

--- a/packages/frontend/src/components/ActiveAgentsList.tsx
+++ b/packages/frontend/src/components/ActiveAgentsList.tsx
@@ -14,6 +14,9 @@ const POLL_INTERVAL_MS = 5000;
 /** z-index for dropdown portal — above Build sidebar (z-50) and Navbar (z-60) */
 const DROPDOWN_Z_INDEX = 9999;
 
+/** Icon size matching two lines of text-sm (line-height 1.25rem * 2 + mt-0.5 gap) */
+const DROPDOWN_AGENT_ICON_SIZE = "2.625rem";
+
 interface ActiveAgentsListProps {
   projectId: string;
 }
@@ -160,7 +163,8 @@ export function ActiveAgentsList({ projectId }: ActiveAgentsListProps) {
                   <img
                     src={getAgentIconSrc(agent)}
                     alt=""
-                    className="shrink-0 self-stretch aspect-square"
+                    className="shrink-0"
+                    style={{ width: DROPDOWN_AGENT_ICON_SIZE, height: DROPDOWN_AGENT_ICON_SIZE }}
                     aria-hidden
                   />
                   <div className="min-w-0 flex-1">


### PR DESCRIPTION
self-stretch + aspect-square caused the icon to fill the entire flex container (including padding). Replace with a fixed square size of 2.625rem (2 * 1.25rem line-height + 0.125rem gap), which matches the height of the two-line text block.